### PR TITLE
remove python as a runtime dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # seems Windows with MSVC not currently supported
   skip: True  # [win]
   features:
@@ -25,7 +25,6 @@ requirements:
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
   run:
-    - python
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
 


### PR DESCRIPTION
My mistake - cut and paste error! The package does *not* need python to run....